### PR TITLE
feat: enable CloudKit entitlement in app config to enable automatic syncing

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,19 @@ This module also includes a plugin configuration. For iCloud, the default contai
     ]
 ```
 
+Add the following lines to your `app.json/app.config.js` file to enable the CloudKit capabilities automatically:
+
+```json
+    ...,
+    "ios": {
+      ...
+      "entitlements": {
+        "com.apple.developer.icloud-services": ["CloudKit"]
+      },
+    },
+    ...
+```
+
 ## Usage
 
 This module only has one method, `getUserIdentity()`, which returns a promise that resolves to a string.

--- a/plugin/src/index.ts
+++ b/plugin/src/index.ts
@@ -81,8 +81,6 @@ export function setICloudEntitlements(
     'com.apple.developer.ubiquity-kvstore-identifier'
   ] = `$(TeamIdentifierPrefix)${config.ios.bundleIdentifier}`
 
-  entitlements['com.apple.developer.icloud-services'] = ['CloudKit']
-
   return entitlements
 }
 


### PR DESCRIPTION
Although the config plugin was configuring the CloudKit containers, the entitlements weren't being automatically synced with the project. By adding the entitlement to the app.json/app.config.js file, this will automatically sync the CloudKit entitlement during the prebuild phase.